### PR TITLE
Cleanup of exception handling, removing unneeded method

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/iosbuilder/signing/PKCS12Archive.java
+++ b/src/main/java/org/jenkinsci/plugins/iosbuilder/signing/PKCS12Archive.java
@@ -12,6 +12,9 @@ import java.util.Map;
 public class PKCS12Archive {
     private final Map<PrivateKey, Certificate> content;
 
+    // Used in the jelly templates
+    public Map<PrivateKey, Certificate> getContent() { return content; }
+
     PKCS12Archive(byte[] data, char[] password) throws IOException {
         try {
             content = new HashMap<PrivateKey, Certificate>();

--- a/src/main/java/org/jenkinsci/plugins/iosbuilder/signing/PKCS12Archive.java
+++ b/src/main/java/org/jenkinsci/plugins/iosbuilder/signing/PKCS12Archive.java
@@ -12,8 +12,6 @@ import java.util.Map;
 public class PKCS12Archive {
     private final Map<PrivateKey, Certificate> content;
 
-    public Map<PrivateKey, Certificate> getContent() { return content; }
-
     PKCS12Archive(byte[] data, char[] password) throws IOException {
         try {
             content = new HashMap<PrivateKey, Certificate>();
@@ -21,20 +19,14 @@ public class PKCS12Archive {
             keyStore.load(new ByteArrayInputStream(data), password);
             Enumeration<String> aliases = keyStore.aliases();
             while (aliases.hasMoreElements()) {
-                try {
-                    String alias = aliases.nextElement();
-                    PrivateKey privateKey = PrivateKeyFactory.newInstance(alias, keyStore, password);
-                    Certificate certificate = CertificateFactory.newInstance((X509Certificate) keyStore.getCertificate(alias));
-                    content.put(privateKey, certificate);
-                }
-                catch (Exception e) {
-                    e.printStackTrace();
-                }
+                String alias = aliases.nextElement();
+                PrivateKey privateKey = PrivateKeyFactory.newInstance(alias, keyStore, password);
+                Certificate certificate = CertificateFactory.newInstance((X509Certificate) keyStore.getCertificate(alias));
+                content.put(privateKey, certificate);
             }
         }
         catch (Exception e) {
-            e.printStackTrace();
-            throw new IOException("Can not instantiate PKCS#12 archive object");
+            throw new IOException("Can not instantiate PKCS#12 archive object", e);
         }
         if (content.size() == 0) {
             throw new IOException("Can not instantiate PKCS#12 archive object: private keys were not found");
@@ -42,18 +34,12 @@ public class PKCS12Archive {
     }
 
     public Identity chooseIdentity(Certificate[] certificates) {
-        try {
-            for (Certificate certificate : certificates) {
-                for (PrivateKey privateKey : content.keySet()) {
-                    if (privateKey.checkPublicKey(certificate.getPublicKey())) {
-                        return new Identity(privateKey, certificate);
-                    }
+        for (Certificate certificate : certificates) {
+            for (PrivateKey privateKey : content.keySet()) {
+                if (privateKey.checkPublicKey(certificate.getPublicKey())) {
+                    return new Identity(privateKey, certificate);
                 }
             }
-        }
-        catch (Exception e) {
-            e.printStackTrace();
-            return null;
         }
         return null;
     }

--- a/src/main/java/org/jenkinsci/plugins/iosbuilder/signing/PKCS12ArchiveFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/iosbuilder/signing/PKCS12ArchiveFactory.java
@@ -3,22 +3,14 @@ package org.jenkinsci.plugins.iosbuilder.signing;
 import hudson.util.Secret;
 import sun.misc.BASE64Decoder;
 
+import java.io.IOException;
+
 public class PKCS12ArchiveFactory {
-    public static PKCS12Archive newInstance(byte[] data, char[] password) {
-        try {
-            return new PKCS12Archive(data, password);
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
-        }
+    public static PKCS12Archive newInstance(byte[] data, char[] password) throws IOException {
+        return new PKCS12Archive(data, password);
     }
 
-    public static PKCS12Archive newInstance(String encodedData, Secret password) {
-        try {
-            return newInstance(new BASE64Decoder().decodeBuffer(encodedData), Secret.toString(password).toCharArray());
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
-        }
+    public static PKCS12Archive newInstance(String encodedData, Secret password) throws IOException {
+        return newInstance(new BASE64Decoder().decodeBuffer(encodedData), Secret.toString(password).toCharArray());
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/iosbuilder/signing/PKCS12ArchiveFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/iosbuilder/signing/PKCS12ArchiveFactory.java
@@ -13,4 +13,12 @@ public class PKCS12ArchiveFactory {
     public static PKCS12Archive newInstance(String encodedData, Secret password) throws IOException {
         return newInstance(new BASE64Decoder().decodeBuffer(encodedData), Secret.toString(password).toCharArray());
     }
+
+    public static PKCS12Archive newSafeInstance(String encodedData, Secret password) throws IOException {
+        try {
+            return newInstance(encodedData, password);
+        } catch (IOException e) {
+            return null;
+        }
+    }
 }

--- a/src/main/resources/org/jenkinsci/plugins/iosbuilder/iOSBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/iosbuilder/iOSBuilder/config.jelly
@@ -49,7 +49,7 @@
             <j:invokeStatic className="java.util.UUID" method="randomUUID" var="detailsId" />
             <j:set var="url" value="${baseURL}inputId=${inputId}"/>
 
-            <j:invokeStatic className="org.jenkinsci.plugins.iosbuilder.signing.PKCS12ArchiveFactory" method="newInstance" var="pkcs12Archive">
+            <j:invokeStatic className="org.jenkinsci.plugins.iosbuilder.signing.PKCS12ArchiveFactory" method="newSafeInstance" var="pkcs12Archive">
                 <j:arg type="java.lang.String" value="${instance.pkcs12ArchiveData}" />
                 <j:arg type="hudson.util.Secret" value="${instance.pkcs12ArchivePassword}" />
             </j:invokeStatic>


### PR DESCRIPTION
Before the e.printStackTrace() data was written to the global jenkins log. This change makes sure that exceptions are logged within the job that triggered them (making it easier to debug issues)
